### PR TITLE
Feature/serial

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -382,20 +382,21 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.42"
+version = "3.1.43"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.42-py3-none-any.whl", hash = "sha256:1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd"},
-    {file = "GitPython-3.1.42.tar.gz", hash = "sha256:2d99869e0fef71a73cbd242528105af1d6c1b108c60dfabd994bf292f76c3ceb"},
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar"]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
 name = "iniconfig"
@@ -971,13 +972,13 @@ files = [
 
 [[package]]
 name = "readchar"
-version = "4.0.5"
+version = "4.0.6"
 description = "Library to easily read single chars and key strokes"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "readchar-4.0.5-py3-none-any.whl", hash = "sha256:76ec784a5dd2afac3b7da8003329834cdd9824294c260027f8c8d2e4d0a78f43"},
-    {file = "readchar-4.0.5.tar.gz", hash = "sha256:08a456c2d7c1888cde3f4688b542621b676eb38cd6cfed7eb6cb2e2905ddc826"},
+    {file = "readchar-4.0.6-py3-none-any.whl", hash = "sha256:b4b31dd35de4897be738f27e8f9f62426b5fedb54b648364987e30ae534b71bc"},
+    {file = "readchar-4.0.6.tar.gz", hash = "sha256:e0dae942d3a746f8d5423f83dbad67efe704004baafe31b626477929faaee472"},
 ]
 
 [package.dependencies]
@@ -1085,13 +1086,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.9.0"
+version = "0.9.4"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee"},
-    {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
+    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
+    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
 ]
 
 [package.dependencies]
@@ -1105,7 +1106,7 @@ typing-extensions = ">=3.7.4.3"
 all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
 doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
-test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-pyserial"
@@ -1350,4 +1351,4 @@ all = ["winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Wind
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "9da9f374a86ef06ad34a0749a33da11167e5844047a80340449644a0b93000c8"
+content-hash = "785c28f70f438406990713b69660932b874bd9fe7ad747409940b0c251ab6359"

--- a/poetry.lock
+++ b/poetry.lock
@@ -970,6 +970,20 @@ files = [
 ]
 
 [[package]]
+name = "readchar"
+version = "4.0.5"
+description = "Library to easily read single chars and key strokes"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "readchar-4.0.5-py3-none-any.whl", hash = "sha256:76ec784a5dd2afac3b7da8003329834cdd9824294c260027f8c8d2e4d0a78f43"},
+    {file = "readchar-4.0.5.tar.gz", hash = "sha256:08a456c2d7c1888cde3f4688b542621b676eb38cd6cfed7eb6cb2e2905ddc826"},
+]
+
+[package.dependencies]
+setuptools = ">=41.0"
+
+[[package]]
 name = "rich"
 version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ source = "git-tag"
 python = ">=3.10, <3.13"
 smpclient = "^1.3.1"
 typer = {extras = ["all"], version = "^0.9.0"}
+readchar = "^4.0.5"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -15,7 +15,7 @@ from smpclient.requests.image_management import ImageStatesWrite
 from smpclient.requests.os_management import ResetWrite
 from typing_extensions import Annotated
 
-from smpmgr import image_management, os_management
+from smpmgr import image_management, os_management, terminal
 from smpmgr.common import (
     Options,
     TransportDefinition,
@@ -38,6 +38,7 @@ app: Final = typer.Typer(help="\n".join(HELP_LINES))
 app.add_typer(os_management.app)
 app.add_typer(image_management.app)
 app.add_typer(intercreate.app)
+app.command()(terminal.terminal)
 
 
 @app.callback(invoke_without_command=True)

--- a/smpmgr/terminal.py
+++ b/smpmgr/terminal.py
@@ -65,10 +65,13 @@ async def _rx_from_device(port: Serial) -> None:
 def _tx_keyboard_to_device(port: Serial) -> None:
     """Blocking read of keyboard input."""
     while True:
-        char = readchar.readchar()
-        if char == readchar.key.CTRL_T:
+        try:
+            key = readchar.readkey()
+        except KeyboardInterrupt:
+            key = readchar.key.CTRL_C
+        if key == readchar.key.CTRL_T:
             raise KeyboardInterrupt
         try:
-            port.write(MAP_KEY_TO_BYTES[char])
+            port.write(MAP_KEY_TO_BYTES[key])
         except KeyError:
-            port.write(char.encode())
+            port.write(key.encode())

--- a/smpmgr/terminal.py
+++ b/smpmgr/terminal.py
@@ -45,7 +45,7 @@ def terminal(ctx: typer.Context) -> None:
                 return_when=asyncio.FIRST_EXCEPTION,
             )
 
-        logger.debug(f"{device_result=}, {keyboard_result=}")
+            logger.debug(f"{device_result=}, {keyboard_result=}")
 
     asyncio.run(f())
 

--- a/smpmgr/terminal.py
+++ b/smpmgr/terminal.py
@@ -1,0 +1,48 @@
+import asyncio
+from typing import cast
+
+import readchar
+import typer
+from serial import Serial
+
+from smpmgr.common import Options
+
+
+def terminal(ctx: typer.Context) -> None:
+    """Open a terminal to the device."""
+
+    options = cast(Options, ctx.obj)
+
+    async def rx_from_device(port: Serial) -> None:
+        while True:
+            _bytes = port.read_all()
+            if _bytes is not None:
+                print(_bytes.decode(), end="", flush=True)
+            await asyncio.sleep(0.020)
+
+    def tx_keyboard_to_device(port: Serial) -> None:
+        while True:
+            char = readchar.readkey()
+            if char == readchar.key.CTRL_C:
+                raise KeyboardInterrupt
+            elif char == readchar.key.UP:
+                port.write(b"\x1b[A")
+            elif char == readchar.key.DOWN:
+                port.write(b"\x1b[B")
+            else:
+                port.write(char.encode())
+
+    async def f() -> None:
+
+        loop = asyncio.get_event_loop()
+
+        with Serial(port=options.transport.port, baudrate=115200, timeout=options.timeout) as s:
+            device_result, keyboard_result = await asyncio.gather(
+                rx_from_device(s),
+                loop.run_in_executor(None, tx_keyboard_to_device, s),
+                return_exceptions=True,
+            )
+
+        print(device_result, keyboard_result)
+
+    asyncio.run(f())

--- a/smpmgr/terminal.py
+++ b/smpmgr/terminal.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Final, cast
 
 import readchar
@@ -6,6 +7,8 @@ import typer
 from serial import Serial
 
 from smpmgr.common import Options
+
+logger = logging.getLogger(__name__)
 
 MAP_KEY_TO_BYTES: Final = {
     readchar.key.CTRL_C: b"\x03",
@@ -42,7 +45,7 @@ def terminal(ctx: typer.Context) -> None:
                 return_when=asyncio.FIRST_EXCEPTION,
             )
 
-        print(device_result, keyboard_result)
+        logger.debug(f"{device_result=}, {keyboard_result=}")
 
     asyncio.run(f())
 

--- a/smpmgr/terminal.py
+++ b/smpmgr/terminal.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import cast
+from typing import Final, cast
 
 import readchar
 import typer
@@ -7,42 +7,65 @@ from serial import Serial
 
 from smpmgr.common import Options
 
+MAP_KEY_TO_BYTES: Final = {
+    readchar.key.CTRL_C: b"\x03",
+    readchar.key.UP: b"\x1b[A",
+    readchar.key.DOWN: b"\x1b[B",
+    readchar.key.LEFT: b"\x1b[D",
+    readchar.key.RIGHT: b"\x1b[C",
+    readchar.key.ESC: b"\x1b",
+}
+
 
 def terminal(ctx: typer.Context) -> None:
     """Open a terminal to the device."""
 
     options = cast(Options, ctx.obj)
 
-    async def rx_from_device(port: Serial) -> None:
-        while True:
-            _bytes = port.read_all()
-            if _bytes is not None:
-                print(_bytes.decode(), end="", flush=True)
-            await asyncio.sleep(0.020)
-
-    def tx_keyboard_to_device(port: Serial) -> None:
-        while True:
-            char = readchar.readkey()
-            if char == readchar.key.CTRL_C:
-                raise KeyboardInterrupt
-            elif char == readchar.key.UP:
-                port.write(b"\x1b[A")
-            elif char == readchar.key.DOWN:
-                port.write(b"\x1b[B")
-            else:
-                port.write(char.encode())
-
     async def f() -> None:
+        if options.transport.port is None:
+            print("--port <port> option is required for the terminal, e.g.")
+            print("smpmgr --port COM1 terminal")
+            return
 
-        loop = asyncio.get_event_loop()
+        print(f"\x1b[2mOpening terminal to {options.transport.port}...", end="")
 
         with Serial(port=options.transport.port, baudrate=115200, timeout=options.timeout) as s:
-            device_result, keyboard_result = await asyncio.gather(
-                rx_from_device(s),
-                loop.run_in_executor(None, tx_keyboard_to_device, s),
-                return_exceptions=True,
+            print("OK")
+            print("Press Ctrl-T to exit the terminal.\x1b[22m")
+            print()
+            device_result, keyboard_result = await asyncio.wait(
+                (
+                    asyncio.create_task(_rx_from_device(s)),
+                    asyncio.create_task(asyncio.to_thread(_tx_keyboard_to_device, s)),
+                ),
+                return_when=asyncio.FIRST_EXCEPTION,
             )
 
         print(device_result, keyboard_result)
 
     asyncio.run(f())
+
+
+async def _rx_from_device(port: Serial) -> None:
+    """Async poll of the serial port for incoming data.
+
+    Can be replaced when pyserial is replaced."""
+
+    while True:
+        _bytes = port.read_all()
+        if _bytes is not None:
+            print(_bytes.decode(), end="", flush=True)
+        await asyncio.sleep(0.020)
+
+
+def _tx_keyboard_to_device(port: Serial) -> None:
+    """Blocking read of keyboard input."""
+    while True:
+        char = readchar.readchar()
+        if char == readchar.key.CTRL_T:
+            raise KeyboardInterrupt
+        try:
+            port.write(MAP_KEY_TO_BYTES[char])
+        except KeyError:
+            port.write(char.encode())


### PR DESCRIPTION
This adds a very simple serial terminal the smpmgr.  Known issues would include that it does not buffer ANSI escapes, so if it flushes to the shell it's running in before the sequence has completed the ANSI escape will not be parsed correctly.  It also seems to hang until you hit enter when the device is unplugged, for example.  And I've only tested from Windows.

The idea is so that users don't have to switch apps for devices that need serial comms to enter the bootloader:

```
smpmgr --port COM1 terminal

# now in the devices Zephyr shell do
bootloader reboot

smpmgr --port COM1 os echo hello
smpmgr --port COM1 os reset
```
