### PR TITLE
add UDP support

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -11,9 +11,9 @@ from serial import SerialException
 from smp.exceptions import SMPBadStartDelimiter
 from smpclient import SMPClient
 from smpclient.generics import SMPRequest, TEr1, TEr2, TRep
-from smpclient.transport.udp import SMPUDPTransport
 from smpclient.transport.ble import SMPBLETransport
 from smpclient.transport.serial import SMPSerialTransport
+from smpclient.transport.udp import SMPUDPTransport
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,9 @@ def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> 
             options.transport.ble,
         )
     elif options.transport.ip is not None:
-        logger.info(f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=} and MTU 1024")
+        logger.info(
+            f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=} and MTU 1024"
+        )
         return smp_client_cls(
             SMPUDPTransport(1024),
             options.transport.ip,

--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -11,6 +11,7 @@ from serial import SerialException
 from smp.exceptions import SMPBadStartDelimiter
 from smpclient import SMPClient
 from smpclient.generics import SMPRequest, TEr1, TEr2, TRep
+from smpclient.transport.udp import SMPUDPTransport
 from smpclient.transport.ble import SMPBLETransport
 from smpclient.transport.serial import SMPSerialTransport
 
@@ -26,6 +27,7 @@ TSMPClient = TypeVar(
 class TransportDefinition:
     port: str | None
     ble: str | None
+    ip: str | None
 
 
 @dataclass(frozen=True)
@@ -55,6 +57,12 @@ def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> 
         return smp_client_cls(
             SMPBLETransport(),
             options.transport.ble,
+        )
+    elif options.transport.ip is not None:
+        logger.info(f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=} and MTU 1024")
+        return smp_client_cls(
+            SMPUDPTransport(1024),
+            options.transport.ip,
         )
     else:
         typer.echo(

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -46,6 +46,9 @@ app.command()(terminal.terminal)
 @app.callback(invoke_without_command=True)
 def options(
     ctx: typer.Context,
+    ip: str = typer.Option(
+        None, help="The IP address to connect to for UDP transport"
+    ),
     port: str = typer.Option(
         None, help="The serial port to connect to, e.g. COM1, /dev/ttyACM0, etc."
     ),
@@ -70,7 +73,7 @@ def options(
 
     setup_logging(loglevel, logfile)
 
-    ctx.obj = Options(timeout=timeout, transport=TransportDefinition(port=port, ble=ble), mtu=mtu)
+    ctx.obj = Options(timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip), mtu=mtu)
     logger.info(ctx.obj)
 
     if ctx.invoked_subcommand is None:

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -46,9 +46,7 @@ app.command()(terminal.terminal)
 @app.callback(invoke_without_command=True)
 def options(
     ctx: typer.Context,
-    ip: str = typer.Option(
-        None, help="The IP address to connect to for UDP transport"
-    ),
+    ip: str = typer.Option(None, help="The IP address to connect to for UDP transport"),
     port: str = typer.Option(
         None, help="The serial port to connect to, e.g. COM1, /dev/ttyACM0, etc."
     ),
@@ -73,7 +71,9 @@ def options(
 
     setup_logging(loglevel, logfile)
 
-    ctx.obj = Options(timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip), mtu=mtu)
+    ctx.obj = Options(
+        timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip), mtu=mtu
+    )
     logger.info(ctx.obj)
 
     if ctx.invoked_subcommand is None:


### PR DESCRIPTION
This is adding UDP support from `smpclient` libary to `smpmgr` command-line.

Tested with signed zephyr firmware with the following commands:
```
smpmgr --loglevel INFO --ip 10.9.9.2 upgrade --slot 1 zephyr.signed.bin
smpmgr --ip 10.9.9.2 image state-read
```