### PR TITLE
Feature/shell group

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -109,14 +109,16 @@ async def smp_request(
     options: Options,
     request: SMPRequest[TRep, TEr1, TEr2],
     description: str | None = None,
+    timeout_s: float | None = None,
 ) -> TRep | TEr1 | TEr2:
     with Progress(
         SpinnerColumn(), TextColumn("[progress.description]{task.description}")
     ) as progress:
         description = description or f"Waiting for response to {request.__class__.__name__}..."
+        timeout_s = timeout_s if timeout_s is not None else options.timeout
         task = progress.add_task(description=description, total=None)
         try:
-            r = await asyncio.wait_for(smpclient.request(request), timeout=options.timeout)
+            r = await smpclient.request(request, timeout_s)
             progress.update(task, description=f"{description} OK", completed=True)
             return r
         except asyncio.TimeoutError:

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -191,7 +191,7 @@ def upgrade(
 
 
 @app.command()
-def shell() -> None:
+def interactive() -> None:
     """Open the `smpmgr` interactive shell. Type 'exit' or 'quit' to exit."""
 
     print("".join(HELP_LINES))
@@ -202,8 +202,8 @@ def shell() -> None:
 
         if args[0] in {"exit", "quit"}:
             break
-        if args[0] == "shell":
-            print("The 'shell' command cannot be used from within the shell.")
+        if args[0] == "interactive":
+            print("The 'interactive' command cannot be used from within the shell.")
             continue
 
         try:

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -18,7 +18,7 @@ from smpclient.requests.image_management import ImageStatesWrite
 from smpclient.requests.os_management import ResetWrite
 from typing_extensions import Annotated, assert_never
 
-from smpmgr import file_management, image_management, os_management, terminal
+from smpmgr import file_management, image_management, os_management, shell_management, terminal
 from smpmgr.common import (
     Options,
     TransportDefinition,
@@ -61,6 +61,7 @@ app.add_typer(os_management.app)
 app.add_typer(image_management.app)
 app.add_typer(file_management.app)
 app.add_typer(intercreate.app)
+app.command()(shell_management.shell)
 app.command()(terminal.terminal)
 
 for plugin in plugins:

--- a/smpmgr/shell_management.py
+++ b/smpmgr/shell_management.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 from typing import Annotated as A
 from typing import Final, assert_never, cast
 
@@ -31,7 +32,7 @@ def shell(
         response: Final = await smp_request(
             smpclient,
             options,
-            Execute(argv=command.split(" ")),
+            Execute(argv=shlex.split(command)),
             f"Waiting response to {command}...",
             timeout_s=timeout,
         )

--- a/smpmgr/shell_management.py
+++ b/smpmgr/shell_management.py
@@ -1,0 +1,53 @@
+import asyncio
+from typing import Annotated as A
+from typing import Final, assert_never, cast
+
+import typer
+from rich import print as rich_print
+from smpclient.generics import error, success
+from smpclient.requests.shell_management import Execute
+
+from smpmgr.common import Options, connect_with_spinner, get_smpclient, smp_request
+
+
+def shell(
+    ctx: typer.Context,
+    command: str = typer.Argument(
+        help="Command string to run, e.g. \"gpio conf gpio@49000000 0 i\""
+    ),
+    timeout: float = typer.Option(2.0, help="Timeout in seconds for the command to complete"),
+    verbose: A[
+        bool, typer.Option("--verbose", help="Print the raw success response")  # noqa: F821,F722
+    ] = False,
+) -> None:
+    """Send a shell command to the device."""
+
+    options: Final = cast(Options, ctx.obj)
+    smpclient: Final = get_smpclient(options)
+
+    async def f() -> None:
+        await connect_with_spinner(smpclient, options.timeout)
+
+        response: Final = await smp_request(
+            smpclient,
+            options,
+            Execute(argv=command.split(" ")),
+            f"Waiting response to {command}...",
+            timeout_s=timeout,
+        )
+        if success(response):
+            if response.ret == 0:  # success, regular text color
+                print(response.o)
+            elif response.ret > 0:
+                rich_print(f"[yellow]Return code: {response.ret}[/yellow]")
+                print(response.o)
+            else:  # non-zero return code, error color
+                rich_print(f"[red]{response.o}[/red]")
+            if verbose:
+                rich_print(response)
+        elif error(response):
+            rich_print(response)
+        else:
+            assert_never(response)
+
+    asyncio.run(f())

--- a/smpmgr/shell_management.py
+++ b/smpmgr/shell_management.py
@@ -1,12 +1,13 @@
 import asyncio
 import shlex
 from typing import Annotated as A
-from typing import Final, assert_never, cast
+from typing import Final, cast
 
 import typer
 from rich import print as rich_print
 from smpclient.generics import error, success
 from smpclient.requests.shell_management import Execute
+from typing_extensions import assert_never
 
 from smpmgr.common import Options, connect_with_spinner, get_smpclient, smp_request
 


### PR DESCRIPTION
Support for sending Zephyr shell commands:

```
smpmgr --port /dev/ttyACM1 shell --timeout=5 "encoder_fixture record 10000 2000"
⠋ Connecting to /dev/ttyACM1... OK
⠇ Waiting response to encoder_fixture record 10000 2000... OK

Encoder fixture started:
  File: encoder_fixture_235487.csv
  Interval: 10000 us (100.000 Hz)

Will stop after 2000 ms (ANY KEY to interrupt)
Stopping encoder fixture recording...
Encoder fixture stopped. Recorded 200 samples.
```

And add some status for the file download and removed requirement to name the file.

```
smpmgr --port /dev/ttyACM1 file download /lfs1/encoder_fixture_1073423.csv
⠋ Connecting to /dev/ttyACM1... OK
⠸ Downloaded /lfs1/encoder_fixture_1073423.csv
⠸ Saved encoder_fixture_1073423.csv
```