### PR TITLE
fix: use smpclient upstream mtu defaults

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -34,7 +34,7 @@ class TransportDefinition:
 class Options:
     timeout: float
     transport: TransportDefinition
-    mtu: int
+    mtu: int | None
 
 
 def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> TSMPClient:
@@ -59,13 +59,8 @@ def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> 
             options.transport.ble,
         )
     elif options.transport.ip is not None:
-        logger.info(
-            f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=} and MTU 1024"
-        )
-        return smp_client_cls(
-            SMPUDPTransport(1024),
-            options.transport.ip,
-        )
+        logger.info(f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=}")
+        return smp_client_cls(SMPUDPTransport(), options.transport.ip)
     else:
         typer.echo(
             f"A transport option is required; "

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -80,11 +80,13 @@ def options(
         2.0,
         help="Transport timeout in seconds; how long to wait for initial connection and requests.",
     ),
-    mtu: int = typer.Option(
-        4096,
+    mtu: int
+    | None = typer.Option(
+        None,
         help=(
             "Maximum transmission unit supported by the SMP server serial transport."
-            "  Ignored for BLE transport since the BLE connection will report MTU."
+            " Will default to smpclient upstream value."
+            " Ignored for BLE transport since the BLE connection will report MTU."
         ),
     ),
     loglevel: LogLevel = typer.Option(None, help="Debug log level"),


### PR DESCRIPTION
This removes the 4,096B serial MTU default that Intercreate tends to use internally for fast FW updates or file transfers, and removes the 1,024B UDP MTU.

As more people are using smpmgr, the assumption that users would like to default their USB transport for fast upload/download is leading to preventable frustrations. Some devices, like iFixit FixHub, will see FW upgrade upload speeds drop from ~50KBps to ~10KBps with these defaults (users can provide `--mtu 4096` to fix), but we don't expect regular users to be impacted since the vast majority use iFixit-provided SW for FW upgrades. That SW knows the correct buffer sizes for fast USB transfers.

To get better "out of the box" compatibility, this PR defers defaults to [smpclient](https://github.com/intercreate/smpclient), which in turn gets its transport defaults from Zephyr's upstream default KConfigs: https://docs.zephyrproject.org/latest/kconfig.html.

Here are some related issues and discussions:
- https://github.com/intercreate/smpclient/issues/73
- https://github.com/intercreate/smpclient/pull/58 (WIP for exposing transport params to smpclient users like smpmgr)
- https://github.com/golioth/pouch/pull/40#discussion_r2222258482
