### PR TITLE
feat: allow passing serial port baudrate

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -35,12 +35,14 @@ class Options:
     timeout: float
     transport: TransportDefinition
     mtu: int | None
+    baudrate: int | None
 
 
 class SMPSerialTransportKwargs(TypedDict, total=False):
     max_smp_encoded_frame_size: int
     line_length: int
     line_buffers: int
+    baudrate: int
 
 
 def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> TSMPClient:
@@ -54,6 +56,8 @@ def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> 
             kwargs['max_smp_encoded_frame_size'] = options.mtu
             kwargs['line_length'] = options.mtu
             kwargs['line_buffers'] = 1
+        if options.baudrate is not None:
+            kwargs['baudrate'] = options.baudrate
         return smp_client_cls(SMPSerialTransport(**kwargs), options.transport.port)
     elif options.transport.ble is not None:
         logger.info(f"Initializing SMPClient with the SMPBLETransport, {options.transport.ble=}")

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -89,6 +89,14 @@ def options(
             " Ignored for BLE transport since the BLE connection will report MTU."
         ),
     ),
+    baudrate: int
+    | None = typer.Option(
+        None,
+        help=(
+            "The baudrate of the serial port to connect to, e.g. 115200."
+            " Will default to smpclient upstream value."
+        ),
+    ),
     loglevel: LogLevel = typer.Option(None, help="Debug log level"),
     logfile: Path = typer.Option(None, help="Log file path"),
     version: Annotated[bool, typer.Option("--version", help="Show the version and exit.")] = False,
@@ -108,7 +116,10 @@ def options(
     setup_logging(loglevel, logfile)
 
     ctx.obj = Options(
-        timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip), mtu=mtu
+        timeout=timeout,
+        transport=TransportDefinition(port=port, ble=ble, ip=ip),
+        mtu=mtu,
+        baudrate=baudrate,
     )
     logger.info(ctx.obj)
 


### PR DESCRIPTION
I'd like to increase the speed of uploading images to my device.
Doubling the smpclient default baudrate doubles the upload speed.

After that something else limits the upload rate, but still investigating that, trying to get 1M baudrate to work as fast as possible.