### PR TITLE
feat: Introduce ForwardTree protocol

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -3,11 +3,12 @@
 import asyncio
 import logging
 from dataclasses import dataclass, fields
-from typing import Type, TypeVar
+from typing import List, Type, TypeVar
 
 import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from serial import SerialException
+from smp import header as smpheader
 from smp.exceptions import SMPBadStartDelimiter
 from smpclient import SMPClient
 from smpclient.generics import SMPRequest, TEr1, TEr2, TRep
@@ -35,6 +36,7 @@ class Options:
     timeout: float
     transport: TransportDefinition
     mtu: int | None
+    forward_tree: List[int]
 
 
 def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> TSMPClient:
@@ -112,6 +114,17 @@ async def smp_request(
         description = description or f"Waiting for response to {request.__class__.__name__}..."
         timeout_s = timeout_s if timeout_s is not None else options.timeout
         task = progress.add_task(description=description, total=None)
+        if options.forward_tree:
+            new_req = request.model_dump()
+            new_header_data = request.header.__dict__.copy()
+            new_header_data['flags'] = smpheader.Flag.FORWARD_TREE
+            new_header_data['length'] = request.header.length + smpheader.ForwardTree.SIZE
+            del new_header_data['_bytes']
+            new_req['header'] = new_header_data
+            new_req['forward_tree'] = smpheader.ForwardTree(options.forward_tree)
+            del new_req['smp_data']
+            del new_req['sequence']
+            request = request.__class__(**new_req)
         try:
             r = await smpclient.request(request, timeout_s)
             progress.update(task, description=f"{description} OK", completed=True)

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -1,11 +1,12 @@
 """Entry point for the `smpmgr` application."""
 
+import ast
 import asyncio
 import logging
 import sys
 from importlib.metadata import version as get_version
 from pathlib import Path
-from typing import Final, cast
+from typing import Final, List, cast
 
 import typer
 import typer.rich_utils
@@ -68,6 +69,34 @@ for plugin in plugins:
     app.add_typer(plugin.app)
 
 
+def parse_list_callback(ctx: typer.Context, param: typer.CallbackParam, value: List[str]) -> List[int]:
+    """
+    Callback function to parse a string representation of a list into integers.
+    Designed to work with Typer's callback system.
+    """
+    if not value:
+        return []
+
+    # Extract the first element as Typer passes values as a list
+    input_str = value[0]
+
+    try:
+        # Parse the string using ast.literal_eval for safety
+        parsed = ast.literal_eval(input_str)
+        if not isinstance(parsed, list):
+            raise typer.BadParameter("Input must be a valid list enclosed in brackets")
+
+        # Validate all elements are integers
+        for item in parsed:
+            if not isinstance(item, int):
+                raise typer.BadParameter(f"All elements must be integers. Found: {item}")
+
+        return parsed
+
+    except (ValueError, SyntaxError) as e:
+        raise typer.BadParameter(f"Invalid list format: {input_str}. Use Python list syntax like '[1, 2, 3, 4]'") from e
+
+
 @app.callback(invoke_without_command=True)
 def options(
     ctx: typer.Context,
@@ -95,6 +124,14 @@ def options(
     plugin_path: Path = typer.Option(
         None, help="Path to plugin directory. May be used more than once."
     ),
+    forward_tree: Annotated[
+        List[str],
+        typer.Option(
+            "--forward-tree",
+            callback=parse_list_callback,
+            parser=lambda x: x,
+            help="List of integers as a string (e.g., '[1, 2, 3, 4]')"
+        )] = None,
 ) -> None:
     if plugin_path:
         raise ValueError(
@@ -108,7 +145,8 @@ def options(
     setup_logging(loglevel, logfile)
 
     ctx.obj = Options(
-        timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip), mtu=mtu
+        timeout=timeout, transport=TransportDefinition(port=port, ble=ble, ip=ip),
+        mtu=mtu, forward_tree=forward_tree
     )
     logger.info(ctx.obj)
 


### PR DESCRIPTION
This add a new command line parameter to capture the Forward Tree protocol data and store in the options structure. Then later before a request be dispatched the system inspects and fill the Forward Tree information.

depends on https://github.com/JPHutchins/smp/pull/49