### PR TITLE
fix: use MTU for UDP transport if supplied in options

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -60,7 +60,10 @@ def get_custom_smpclient(options: Options, smp_client_cls: Type[TSMPClient]) -> 
         )
     elif options.transport.ip is not None:
         logger.info(f"Initializing SMPClient with the SMPUDPTransport, {options.transport.ip=}")
-        return smp_client_cls(SMPUDPTransport(), options.transport.ip)
+        if options.mtu is not None:
+            return smp_client_cls(SMPUDPTransport(mtu=options.mtu), options.transport.ip)
+        else:
+            return smp_client_cls(SMPUDPTransport(), options.transport.ip)
     else:
         typer.echo(
             f"A transport option is required; "


### PR DESCRIPTION
This allows this (fantastic!) tool to work for uploading firmware images to devices on a Thread network (MTU values of 128, 256, 512 and 1024 tested).

This might have nothing to do with the fact the devices are using Thread, but rather to the UDP/SMP server config. I'm really fuzzy on the details.