### PR TITLE
smpmgr: upload: add --bypass-inspection option for non-MCUboot images

### DIFF
--- a/smpmgr/image_management.py
+++ b/smpmgr/image_management.py
@@ -174,15 +174,30 @@ def upload(
     ctx: typer.Context,
     file: Annotated[Path, typer.Argument(help="Path to FW image")],
     slot: Annotated[int, typer.Option(help="The image slot to upload to")] = 0,
+    bypass_inspect: Annotated[
+        bool,
+        typer.Option(
+            "--bypass-inspect",
+            help="Skip local MCUboot image inspection. "
+            "This is useful when uploading images that are not in MCUboot format, such as "
+            "custom bootloader formats (e.g., NXP's SB3.1). "
+            "[bold red]WARNING[/bold red]: When using this option, the responsibility for "
+            "validating image integrity is placed entirely on the device's bootloader. "
+            "If the bootloader does not verify the image, corrupted firmware could be uploaded. "
+            "[bold red]Only use this option if your bootloader performs its own image integrity "
+            "validation.[/bold red]",
+        ),
+    ] = False,
 ) -> None:
     """Upload a FW image."""
 
-    try:
-        image_info = ImageInfo.load_file(str(file))
-        logger.info(str(image_info))
-    except Exception:
-        logger.exception("Inspection of FW image failed")
-        raise typer.Exit(code=1)
+    if not bypass_inspect:
+        try:
+            image_info = ImageInfo.load_file(str(file))
+            logger.info(str(image_info))
+        except Exception:
+            logger.exception("Inspection of FW image failed")
+            raise typer.Exit(code=1)
 
     options = cast(Options, ctx.obj)
     smpclient = get_smpclient(options)


### PR DESCRIPTION
As done for the upgrade command, allow to upload non-MCUboot images.

It was discussed in #92 the following with @JPHutchins :

> I'd like to merge this and then I will follow up to make the following changes to the API before releasing:
> 
>     * remove `--bypass-inspect` option
> 
>     * replace it with an optional `--image-type=<image type>` field
> 
>     * default `--image-type` to `"mcuboot"`
> 
>     * allow `--image-type=unknown` to do exactly what `--bypass-inspect` does now
> 
> 
> The goal is to support multiple image types in the long run rather than ignoring everything that is not mcuboot.
> 
> LMK if that sounds OK.

As this hasn't be implemented yet, I propose to add a similar bypass mechanism to the upload command until the final rework.






