### PR TITLE
fix: charmap error

### DIFF
--- a/smpmgr/common.py
+++ b/smpmgr/common.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import logging
+import sys
 from dataclasses import dataclass, fields
 from typing import Final, Type, TypedDict, TypeVar, assert_never
 
 import typer
+from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from serial import SerialException
 from smp.exceptions import SMPBadStartDelimiter
@@ -128,7 +130,9 @@ def get_smpclient(options: Options) -> SMPClient:
 async def connect_with_spinner(smpclient: SMPClient) -> None:
     """Spin while connecting to the SMP Server; raises `typer.Exit` if connection fails."""
     with Progress(
-        SpinnerColumn(), TextColumn("[progress.description]{task.description}")
+        SpinnerColumn(spinner_name="line"),
+        TextColumn("[progress.description]{task.description}"),
+        console=Console(force_terminal=sys.stdout.isatty()),
     ) as progress:
         connect_task_description = f"Connecting to {smpclient._address}..."
         connect_task = progress.add_task(description=connect_task_description, total=None)
@@ -156,7 +160,9 @@ async def smp_request(
     timeout_s: float | None = None,
 ) -> TRep | TEr1 | TEr2:
     with Progress(
-        SpinnerColumn(), TextColumn("[progress.description]{task.description}")
+        SpinnerColumn(spinner_name="line"),
+        TextColumn("[progress.description]{task.description}"),
+        console=Console(force_terminal=sys.stdout.isatty()),
     ) as progress:
         description = description or f"Waiting for response to {request.__class__.__name__}..."
         task = progress.add_task(description=description, total=None)

--- a/smpmgr/main.py
+++ b/smpmgr/main.py
@@ -265,9 +265,11 @@ def upgrade(
             image_states_response = await smp_request(
                 smpclient,
                 ImageStatesWrite(hash=image_hash, confirm=confirm),
-                "Marking uploaded image for permanent upgrade..."
-                if confirm
-                else "Marking uploaded image for test upgrade...",
+                (
+                    "Marking uploaded image for permanent upgrade..."
+                    if confirm
+                    else "Marking uploaded image for test upgrade..."
+                ),
             )
             if success(image_states_response):
                 pass


### PR DESCRIPTION
**Context**
When trying to wrap the downloaded `.exe` in Python, I had an issue: `Transport error: connection timeout -         common.py:142 UnicodeEncodeError: 'charmap' codec can't encode character '\\u2826' in position\n0: character maps to <undefined>\n[PYI-27128:ERROR] Failed to execute script '__main__' due to unhandled exception!\n")`.

**Changes**
- forcing the Rich terminal rendering when stdout is actually attached to a terminal.